### PR TITLE
Removing ENTRYPOINT and CMD so that the container does not automatica…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,5 @@ WORKDIR /src
 # Tell Docker where to find the scripts that will run Hugo, build the static site, and deploy that site to AWS.
 # Tell Docker to use the buildDeploy.sh script as an entrypoint (i.e. run the script) when
 # the Docker image is run to create the Docker container and use 'build' as the default Hugo command.
-ENTRYPOINT ["/src/buildDeploy.sh"]
-CMD ["build"]
+#ENTRYPOINT ["/src/buildDeploy.sh"]
+#CMD ["build"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     stage('Build') {
       agent {
         dockerfile {
-          additionalBuildArgs "--build-arg HUGO_COMMAND=build --build-arg DEPLOY_TIER=$DEPLOY_TIER --build-arg AWS_SYNC=sync_yes"
+          additionalBuildArgs "--no-cache --build-arg HUGO_COMMAND=build --build-arg DEPLOY_TIER=$DEPLOY_TIER --build-arg AWS_SYNC=sync_yes"
           args '-u root:root -v "${WORKSPACE}":/src'
           reuseNode true
         }


### PR DESCRIPTION
…lly run anything. Use --no-cache in the Jenkinsfile when building to prevent cached images from being used to build the container.

